### PR TITLE
Fix findnodata ndv output

### DIFF
--- a/rio_alpha/findnodata.py
+++ b/rio_alpha/findnodata.py
@@ -112,6 +112,9 @@ def determine_nodata(src_path, user_nodata, discovery, debug, verbose):
     Returns
     -------
     nodata value: string
+                  string(int) or stringified array of values of
+                  len == the number of bands.
+                  For example, string([int(ndv), int(ndv), int(ndv)])
 
 
     Current pxm-alpha script:
@@ -168,7 +171,7 @@ def determine_nodata(src_path, user_nodata, discovery, debug, verbose):
         if nodata is None:
             if discovery:
                 candidates = discover_ndv(data, debug, verbose)
-                return '{} {} {}'.format(*candidates)
+                return '[{}, {}, {}]'.format(*candidates)
             else:
                 return ""
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,16 +135,16 @@ def test_cli_findnodata_discovery_success():
         'tests/fixtures/dk_all/320_ECW_UTM32-EUREF89.tiny.tif',
         '--discovery'])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == "18 51 62"
+    assert result.output.strip('\n') == "[18, 51, 62]"
 
 
 def test_cli_findnodata_user_nodata_success():
     runner = CliRunner()
     result = runner.invoke(findnodata, [
         'tests/fixtures/dk_all/320_ECW_UTM32-EUREF89.tiny.tif',
-        '--user_nodata', '255 255 255'])
+        '--user_nodata', '[255, 255, 255]'])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == '255 255 255'
+    assert result.output.strip('\n') == '[255, 255, 255]'
 
 
 def test_cli_findnodata_verbose_success():
@@ -153,7 +153,7 @@ def test_cli_findnodata_verbose_success():
         'tests/fixtures/fi_all/W4441A.tiny.tif',
         '--discovery', '--verbose'])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == '255 255 255'
+    assert result.output.strip('\n') == '[255, 255, 255]'
 
 
 def test_cli_findnodata_debug_success():


### PR DESCRIPTION
Resolves https://github.com/mapbox/rio-alpha/issues/15

`rio findnodata` ndv output format changed from `"255 255 255"` to `"[255, 255, 255]"`

cc @jacquestardie 
