### PR TITLE
Change islossy CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Usage: rio islossy [OPTIONS] INPUT
 
   Determine if there are >= 10 nodata regions in an image
 
-  If true, returns the string `--lossy lossy`.
+  If true, returns the string `True`. If false, returns the string 'False'
 
 Options:
   --ndv TEXT  Expects a string containing a single integer value (e.g. '255')

--- a/rio_alpha/scripts/cli.py
+++ b/rio_alpha/scripts/cli.py
@@ -29,9 +29,9 @@ def islossy(input, ndv):
     ndv = _parse_ndv(ndv, 3)
 
     if count_ndv_regions(img, ndv) >= 10:
-        click.echo("--lossy lossy")
+        click.echo("True")
     else:
-        click.echo("")
+        click.echo("False")
 
 
 @click.command('findnodata')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_cli_lossy_single_value_ndv():
         '--ndv', '255'
     ])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == "--lossy lossy"
+    assert result.output.strip('\n') == "True"
 
 
 def test_cli_lossy_single_value_ndv_fail():
@@ -45,21 +45,21 @@ def test_cli_lossy_three_value_ndv():
         '--ndv', '[255, 255, 255]'
     ])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == "--lossy lossy"
+    assert result.output.strip('\n') == "True"
 
     result = runner.invoke(islossy, [
         'tests/fixtures/dk_all/450_ECW_UTM32-EUREF89.tiny.tif',
         '--ndv', '[255, 255, 255]'
     ])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == "--lossy lossy"
+    assert result.output.strip('\n') == "True"
 
     result = runner.invoke(islossy, [
         'tests/fixtures/fi_all/W4441A.tiny.tif',
         '--ndv', '[255, 255, 255]'
     ])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == "--lossy lossy"
+    assert result.output.strip('\n') == "True"
 
 
 def test_cli_lossy_three_value_ndv_fail():
@@ -78,7 +78,7 @@ def test_cli_notlossy_single_value_ndv():
         '--ndv', '255'
     ])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == ""
+    assert result.output.strip('\n') == "False"
 
 
 def test_cli_notlossy_diff_three_value_ndv():
@@ -88,7 +88,7 @@ def test_cli_notlossy_diff_three_value_ndv():
         '--ndv', '[18, 51, 62]'
     ])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == ""
+    assert result.output.strip('\n') == "False"
 
 
 def test_cli_nolossy_same_three_value_ndv():
@@ -98,7 +98,7 @@ def test_cli_nolossy_same_three_value_ndv():
         '--ndv', '[255, 255, 255]'
     ])
     assert result.exit_code == 0
-    assert result.output.strip('\n') == ""
+    assert result.output.strip('\n') == "False"
 
 
 def test_cli_findnodata_default_success():


### PR DESCRIPTION
Ref: https://github.com/mapbox/rio-alpha/issues/20
`islossy` CLI should return "True" or "False" instead of "--lossy lossy":

Files that need to be changed:
- [x] Update [cli.py](https://github.com/mapbox/rio-alpha/blob/381eb5d89029cfe8f23b17c8217389da77809f0c/rio_alpha/scripts/cli.py#L31-L34)
- [x] Update [README](https://github.com/mapbox/rio-alpha/blob/master/README.md#islossy)
- [x] Update [test_cli.py](https://github.com/mapbox/rio-alpha/blob/381eb5d89029cfe8f23b17c8217389da77809f0c/tests/test_cli.py)

cc @jacquestardie 
