### PR TITLE
Fix install requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pip install rio-alpha
 Alternatively, if you're looking to contribute:
 
 ```
-git checkout git@github.com:mapbox/rio-alpha.git
+git clone git@github.com:mapbox/rio-alpha.git
 cd rio-alpha
 pip install -U pip
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -9,16 +9,19 @@ A [rasterio](https://github.com/mapbox/rasterio) plugin for working with nodata.
 Installation
 ------------
 
-```bash
+```
+pip install -U pip
 pip install rio-alpha
 ```
 
 Alternatively, if you're looking to contribute:
 
 ```
-git clone git@github.com:mapbox/rio-alpha.git
+git checkout git@github.com:mapbox/rio-alpha.git
 cd rio-alpha
-pip install -e ".[test]"
+pip install -U pip
+pip install -r requirements.txt
+pip install -e .
 ```
 
 
@@ -42,7 +45,7 @@ Options:
                          documentation for the selected output driver for more
                          information.
   --help                 Show this message and exit.
-  ```
+```
 
 #### `islossy`
 

--- a/rio_alpha/__init__.py
+++ b/rio_alpha/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())


### PR DESCRIPTION
This PR fixes pip install fails: Added MANIFEST.in
```
❯ pip install rio-alpha                                                                                                     
Collecting rio-alpha
  Downloading rio-alpha-0.4.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/6x/80zxrf7j5bs42vq6hh4wh69h0000gn/T/pip-build-iTTtXX/rio-alpha/setup.py", line 36, in <module>
        install_requires=read('requirements.txt').splitlines(),
      File "/private/var/folders/6x/80zxrf7j5bs42vq6hh4wh69h0000gn/T/pip-build-iTTtXX/rio-alpha/setup.py", line 19, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
    IOError: [Errno 2] No such file or directory: '/private/var/folders/6x/80zxrf7j5bs42vq6hh4wh69h0000gn/T/pip-build-iTTtXX/rio-alpha/requirements.txt'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/6x/80zxrf7j5bs42vq6hh4wh69h0000gn/T/pip-build-iTTtXX/rio-alpha/
```

cc @jacquestardie 