### PR TITLE
Avoid deprecation warnings with rasterio>=1.0a10

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,6 @@
+CHANGES
+
+Next
+----
+- Use rasterio's Window class when possible to avoid deprecation warnings
+  (#35).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ cligj
 coveralls>=0.4
 delocate
 enum34
+mock
 numpy>=1.8.0
 snuggs>=1.2
 pytest

--- a/rio_alpha/alpha.py
+++ b/rio_alpha/alpha.py
@@ -8,17 +8,21 @@ from rio_alpha.alpha_mask import mask_exact
 try:
     from rasterio.windows import Window
 except ImportError:
-    class Window:
-        def from_slices(self, window):
-            return window
+    Window = None
 
 
 def window_guard(window):
     """Normalize window input to match rasterio version"""
-    if isinstance(window, Window):
-        return window
+    if Window is not None:
+        if isinstance(window, Window):
+            return window
+        else:
+            if hasattr(Window, 'from_slices'):
+                return Window.from_slices(*window)
+            else:
+                return Window.from_ranges(*window)
     else:
-        return Window.from_slices(*window)
+        return window
 
 
 def _alpha_worker(open_file, window, ij, g_args):

--- a/rio_alpha/alpha.py
+++ b/rio_alpha/alpha.py
@@ -9,7 +9,9 @@ try:
     from rasterio.windows import Window
 except ImportError:
     class Window:
-        pass
+        def from_slices(self, window):
+            return window
+
 
 def window_guard(window):
     """Normalize window input to match rasterio version"""

--- a/tests/test_window_guard.py
+++ b/tests/test_window_guard.py
@@ -1,6 +1,6 @@
 """Window guard tests"""
 
-from unittest.mock import patch
+from mock import patch
 
 import pytest
 

--- a/tests/test_window_guard.py
+++ b/tests/test_window_guard.py
@@ -12,8 +12,8 @@ class MockWindow:
 
 
 def test_import_window():
-    windows_mod = pytest.importorskip("rasterio.windows")
-    window = windows_mod.Window(0, 0, 10, 10)
+    window_cls = pytest.importorskip("rasterio.windows.Window")
+    window = window_cls(0, 0, 10, 10)
     assert rio_alpha.alpha.window_guard(window) == window
 
 
@@ -24,6 +24,6 @@ def test_window():
 
 
 def test_tuple_convert():
-    windows_mod = pytest.importorskip("rasterio.windows")
+    window_cls = pytest.importorskip("rasterio.windows.Window")
     window = ((1, 2), (3, 4))
-    assert rio_alpha.alpha.window_guard(window) == windows_mod.Window(3, 1, 1, 1)
+    assert rio_alpha.alpha.window_guard(window) == window_cls(3, 1, 1, 1)

--- a/tests/test_window_guard.py
+++ b/tests/test_window_guard.py
@@ -26,4 +26,4 @@ def test_window():
 def test_tuple_convert():
     windows_mod = pytest.importorskip("rasterio.windows")
     window = ((1, 2), (3, 4))
-    assert rio_alpha.alpha.window_guard(window) == windows_mod.Window.from_slices(*window)
+    assert rio_alpha.alpha.window_guard(window) == windows_mod.Window(3, 1, 1, 1)

--- a/tests/test_window_guard.py
+++ b/tests/test_window_guard.py
@@ -1,0 +1,29 @@
+"""Window guard tests"""
+
+from unittest.mock import patch
+
+import pytest
+
+import rio_alpha.alpha
+
+
+class MockWindow:
+    pass
+
+
+def test_import_window():
+    windows_mod = pytest.importorskip("rasterio.windows")
+    window = windows_mod.Window(0, 0, 10, 10)
+    assert rio_alpha.alpha.window_guard(window) == window
+
+
+@patch('rio_alpha.alpha.Window', MockWindow)
+def test_window():
+    window = MockWindow()
+    assert rio_alpha.alpha.window_guard(window) == window
+
+
+def test_tuple_convert():
+    windows_mod = pytest.importorskip("rasterio.windows")
+    window = ((1, 2), (3, 4))
+    assert rio_alpha.alpha.window_guard(window) == windows_mod.Window.from_slices(*window)


### PR DESCRIPTION
This change is intended to let pxm run more quietly.